### PR TITLE
Fix Github URL and set `net.git-fetch-with-cli=true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tested with the files in the `cards-example` project. (Currently the tests fail 
 ## Installation
 
 ```bash
-cargo install --git github.com/flyinpancake/svg2pbc-rs
+cargo install --git https://github.com/FlyinPancake/svg2pdc-rs --config net.git-fetch-with-cli=true
 ```
 
 ## Usage


### PR DESCRIPTION
There were two problems with the original:
1. The URL had a typo ("pbc" instead of "pdc")
2. For those who have not added Git auth to Cargo, it presented a generic auth error trying to pull a Git repo. Adding `--config net.git-fetch-with-cli=true` fixed this for me.

(Thank you for your work on this, by the way!)